### PR TITLE
Anpassungen zu Berechtigungen und Texten

### DIFF
--- a/data/res/i18n/de-DE/user.php
+++ b/data/res/i18n/de-DE/user.php
@@ -65,7 +65,7 @@ return array(
     'This account is considered a placeholder and thus cannot login' => 'Leider wurde dieses Benutzerkonto als Platzhalter definiert.',
     'Email address and/or password invalid' => 'E-Mail Adresse und/oder Passwort falsch',
     'This account is currently blocked' => 'Dieses Benutzerkonto ist derzeit gesperrt',
-    'This account has not yet been activated' => 'Dieses Benutzerkonto wurde noch nicht aktiviert',
+    'This account has not yet been activated' => 'Dieses Benutzerkonto wurde noch nicht aktiviert. Vermutlich hast du die E-Mail geändert. Du solltest eine Mail mit einem Aktivierungslink bekommen haben. Schau auch einmal in den Spam-Ordner',
 
     'Welcome, %s' => 'Willkommen, %s',
 

--- a/module/Calendar/src/Calendar/Controller/CalendarController.php
+++ b/module/Calendar/src/Calendar/Controller/CalendarController.php
@@ -105,7 +105,7 @@ class CalendarController extends AbstractActionController
 
         $getBookingUsers = false;
 
-        if ($user && $user->can('calendar.see-data')) {
+        if ($user && $user->can('calendar.see-past , calendar.see-data')) {
             $getBookingUsers = true;
             $dateNow->setTime(0, 0, 0);
         }

--- a/module/Calendar/src/Calendar/View/Helper/Cell/Render/Occupied.php
+++ b/module/Calendar/src/Calendar/View/Helper/Cell/Render/Occupied.php
@@ -13,7 +13,24 @@ class Occupied extends AbstractHelper
         $view = $this->getView();
 
         if ($user && $user->can('calendar.see-data')) {
-            return $view->calendarCellRenderOccupiedForPrivileged($reservations, $cellLinkParams);
+			return $view->calendarCellRenderOccupiedForPrivileged($reservations, $cellLinkParams);
+        }else if ($user && $user->can('calendar.see-past')){
+            if ($userBooking) {
+                $cellLabel = $view->t('Your Booking');
+                $cellGroup = ' cc-group-' . $userBooking->need('bid');
+
+                return $view->calendarCellLink($cellLabel, $view->url('square', [], $cellLinkParams), 'cc-own' . $cellGroup);
+            } else{
+				
+				
+				$reservation = current($reservations);
+				$booking = $reservation->needExtra('booking');
+				$uid = $booking->get('uid');
+				$cellLabel = $reservation->getExtra('booking')->getExtra('user')->get('alias');
+				#$cellLabel = $view->t('Your Booking');
+                $cellGroup = ' cc-group-' . $booking->need('bid');
+
+                return $view->calendarCellLink($cellLabel, $view->url('square', [], $cellLinkParams), 'cc-single' . $cellGroup);}
         } else if ($user) {
             if ($userBooking) {
                 $cellLabel = $view->t('Your Booking');

--- a/module/Square/view/square/square/index.occupied.phtml
+++ b/module/Square/view/square/square/index.occupied.phtml
@@ -4,7 +4,44 @@ $squareType = $this->option('subject.square.type');
 
 if ($this->notBookableReason) {
     $reason = $this->notBookableReason;
-} else {
+} else if ($user->can('calendar.see-past')){
+
+    $outputPlayerNames = null;
+    if ($user !== null) {
+        // Mitspieler holen
+        foreach ($bookings as $booking) {
+            $reservationOwner = $booking->getExtra('user')->get('alias');
+            if ($outputPlayerNames === null) {
+                $outputPlayerNames = $reservationOwner;
+            } else {
+                $outputPlayerNames .= sprintf(', %1$s', $reservationOwner);
+            }
+            
+            $playerNames = $booking->getMeta('player-names');
+            if ($playerNames) {
+                $playerNames = @unserialize($playerNames);
+                if ($playerNames) {
+                    foreach ($playerNames as $playerData) {
+                        $nameData = trim($playerData['value']);
+                        if ($nameData !== "") {
+                            if ($outputPlayerNames === null) {
+                                $outputPlayerNames = $nameData;
+                            } else {
+                                $outputPlayerNames .= sprintf(', %1$s', $nameData);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    $reason = $this->t('Dieser Platz wurde bereits mit folgenden Spielern gebucht:');
+
+    if ($outputPlayerNames != null) {
+        $reason .= sprintf('<br>(%1$s)', $outputPlayerNames);
+    }
+}else {
     $reason = $this->t('This %s is already occupied.');
 }
 


### PR DESCRIPTION
Anforderung:
Bestimmte Benutzer sollen in die Vergangenheit sehen dürfen, die Namen der User sehen und auch eventuelle Mitspieler sehen, jedoch ohne selber die Admin-Buchungsmaske zu sehen. Hierfür wurde die Berechtigung calendar.see-past entsprechend erweitert. 
Außerdem wurde ein Text angepasst. 